### PR TITLE
Reconnect to gitter and rocketchat after connection shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,16 @@ target/
 local.conf
 *.sqlite
 *.sqlite3
-/*.log.gz
-/*.log
+
+# Logs
+data/
+*.log.gz
+*.log
+
+# Metals and VS Code
+.metals
+.bloop
+.vscode
+project/boot/
+project/plugins/project/
+**/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "nakayoshi"
 
 version := "0.1.1"
 
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.12"
 
 mainClass := Some("jp.co.soramitsu.nakayoshi.Main")
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,6 +3,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>./data/logs/bridge.log</file>
         <encoder>
+            <charset>UTF-8</charset>
             <pattern>%date [%level] %logger in %thread - %message%n%xException</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">

--- a/src/main/scala/jp/co/soramitsu/nakayoshi/BotGitter.scala
+++ b/src/main/scala/jp/co/soramitsu/nakayoshi/BotGitter.scala
@@ -128,6 +128,7 @@ class BotGitter(token: String)
 
       }.recover { case th =>
         l.error(s"Failed to initiate connection to Gitter chat $id", th)
+        timers.startSingleTimer(Symbol(id), MsgGitterListen(id), 1 minute)
       }
     case MsgSendGitter(id, text) =>
       sendMsg(id, text) pipeTo sender()

--- a/src/main/scala/jp/co/soramitsu/nakayoshi/Main.scala
+++ b/src/main/scala/jp/co/soramitsu/nakayoshi/Main.scala
@@ -18,6 +18,8 @@ object Main extends App with Loggable {
   implicit val executionContext: ExecutionContext = system.dispatcher
   implicit val sttpBackend: SttpBackend[Future, Source[ByteString, Any]] = AkkaHttpBackend.usingActorSystem(system)
 
+  l.info("なかよし Bot Started!")
+  
   Await.ready(Storage.create(), Duration(1, MINUTES))
 
   val botTelegram = system.actorOf(Props(


### PR DESCRIPTION
Fixes the bug, that stopped the bot from functioning properly when rocket or gitter streaming API was temporarily shutdown on corresponding servers. Gitter and Rocket actors did not reconnect. This PR is meant to fix it.

Also minor logging and build improvements.